### PR TITLE
feat: add automated release note generation workflow

### DIFF
--- a/.github/workflows/sdk_generation.yaml
+++ b/.github/workflows/sdk_generation.yaml
@@ -32,3 +32,29 @@ jobs:
       github_access_token: ${{ secrets.GITHUB_TOKEN }}
       nuget_api_key: ${{ secrets.NUGET_API_KEY }}
       speakeasy_api_key: ${{ secrets.SPEAKEASY_API_KEY }}
+
+  trigger-release-note:
+    needs: generate
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          ref: main
+      - name: Check if Speakeasy pushed changes
+        id: check
+        run: |
+          AUTHOR=$(git log -1 --format='%ae')
+          if [[ "$AUTHOR" == *"speakeasy"* ]]; then
+            echo "changed=true" >> $GITHUB_OUTPUT
+            echo "sha=$(git log -1 --format='%H')" >> $GITHUB_OUTPUT
+          else
+            echo "changed=false" >> $GITHUB_OUTPUT
+          fi
+      - name: Trigger Release Note workflow
+        if: steps.check.outputs.changed == 'true'
+        run: |
+          curl -sf -X POST \
+            -H "Authorization: Bearer ${{ secrets.GITHUB_TOKEN }}" \
+            -H "Accept: application/vnd.github.v3+json" \
+            "https://api.github.com/repos/${{ github.repository }}/actions/workflows/sdk_release_note.yaml/dispatches" \
+            -d "{\"ref\":\"main\",\"inputs\":{\"commit_sha\":\"${{ steps.check.outputs.sha }}\"}}"

--- a/.github/workflows/sdk_publish.yaml
+++ b/.github/workflows/sdk_publish.yaml
@@ -6,12 +6,12 @@ permissions:
   statuses: write
   id-token: write
 "on":
-  push:
-    branches:
-      - main
-    paths:
-      - .speakeasy/gen.lock
-  workflow_dispatch: {}
+  workflow_dispatch:
+    inputs:
+      commit_sha:
+        description: Commit SHA to generate release notes for
+        type: string
+        required: false
 jobs:
   publish:
     uses: speakeasy-api/sdk-generation-action/.github/workflows/sdk-publish.yaml@v15
@@ -21,3 +21,15 @@ jobs:
       github_access_token: ${{ secrets.GITHUB_TOKEN }}
       nuget_api_key: ${{ secrets.NUGET_API_KEY }}
       speakeasy_api_key: ${{ secrets.SPEAKEASY_API_KEY }}
+
+  trigger-release-note:
+    needs: publish
+    runs-on: ubuntu-latest
+    steps:
+      - name: Trigger Release Note workflow
+        run: |
+          curl -sf -X POST \
+            -H "Authorization: Bearer ${{ secrets.GITHUB_TOKEN }}" \
+            -H "Accept: application/vnd.github.v3+json" \
+            "https://api.github.com/repos/${{ github.repository }}/actions/workflows/sdk_release_note.yaml/dispatches" \
+            -d "{\"ref\":\"main\",\"inputs\":{\"commit_sha\":\"${{ inputs.commit_sha || github.sha }}\"}}"

--- a/.github/workflows/sdk_release_note.yaml
+++ b/.github/workflows/sdk_release_note.yaml
@@ -1,0 +1,57 @@
+name: Release Note
+permissions:
+  contents: read
+  id-token: write
+"on":
+  workflow_dispatch:
+    inputs:
+      commit_sha:
+        description: Commit SHA to generate release notes for
+        type: string
+        required: false
+jobs:
+  notify:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 2
+          ref: ${{ inputs.commit_sha || github.sha }}
+
+      - name: Get version and diff
+        id: info
+        run: |
+          VERSION=$(grep '<Version>' src/Mollie/Mollie.csproj | head -1 | sed 's/.*<Version>\(.*\)<\/Version>.*/\1/')
+          echo "version=$VERSION" >> $GITHUB_OUTPUT
+          SHA="${{ inputs.commit_sha || github.sha }}"
+          {
+            echo "diff<<EOF"
+            git diff ${SHA}~1 ${SHA} -- src/
+            echo "EOF"
+          } >> $GITHUB_OUTPUT
+
+      - name: Summarise with Claude
+        id: summary
+        uses: mollie/mollie-api-release-note-generator@main
+        with:
+          diff: ${{ steps.info.outputs.diff }}
+
+      - name: Send Discord notification
+        env:
+          DISCORD_WEBHOOK_URL: ${{ secrets.DISCORD_WEBHOOK_URL }}
+          VERSION: ${{ steps.info.outputs.version }}
+          SUMMARY: ${{ steps.summary.outputs.release_notes }}
+        run: |
+          curl -sf -X POST "$DISCORD_WEBHOOK_URL" \
+            -H "Content-Type: application/json" \
+            -d "$(jq -n \
+              --arg version "$VERSION" \
+              --arg summary "$SUMMARY" \
+              --arg url "https://github.com/mollie/mollie-api-csharp/releases/tag/v$VERSION" '{
+                embeds: [{
+                  color: 2326507,
+                  title: ("<:csharp:1509112522987274353> C# `v" + $version + "` is out 🎉"),
+                  description: ("A shiny new version just dropped! ✨\nWhat changed? **Great question, glad you asked!**\n\n" + $summary + "\n\nCheck it out [here](" + $url + ")"),
+                  url: $url
+                }]
+              }')"


### PR DESCRIPTION
## What
Adds the same release note pipeline already live in the Python SDK. On every generation where Speakeasy commits a change, a Discord embed is posted with a Claude-generated summary of what changed.

## How
- New `sdk_release_note.yaml`: extracts version from the language package manifest, diffs the commit against its parent, passes the diff to `mollie/mollie-api-release-note-generator` (Claude), and POSTs a Discord embed
- `sdk_generation.yaml`: added `trigger-release-note` job — checks commit author for `speakeasy` and dispatches only on real SDK updates
- `sdk_publish.yaml`: switched trigger from `push` to `workflow_dispatch` only (matching Python, avoids double-triggering) and added `trigger-release-note` job

## Testing
Not testable locally — requires a real Speakeasy generation run with `DISCORD_WEBHOOK_URL` secret configured.